### PR TITLE
feat: add labelled Textarea component with character-limit indicator

### DIFF
--- a/docs/pull_requests/feat-textarea-component.md
+++ b/docs/pull_requests/feat-textarea-component.md
@@ -1,0 +1,27 @@
+# feat: labelled Textarea with character-limit indicator
+
+## Summary
+Implements the `Textarea` UI component per `docs/design/design_system.md`.
+
+## Changes
+- `src/components/ui/Textarea.tsx` — new component
+- `tests/Textarea.test.tsx` — 7 tests (all passing)
+
+## States
+| State | Trigger |
+|---|---|
+| Default | No value, not focused |
+| Focus/Active | `state="focus"` prop or textarea focused |
+| Filled/Inactive | `state="filled"` prop or has value, not focused |
+| Error | `state="error"` prop or character count reaches `maxLength` (200) |
+
+## Acceptance Criteria
+- [x] All four states reachable via `state` prop
+- [x] Live character count vs. max (200) displayed as `n/200`
+- [x] Accessible: `aria-describedby`, `aria-invalid`, `role="alert"`, `htmlFor` label association
+
+## Testing
+```bash
+pnpm test tests/Textarea.test.tsx
+```
+All 7 tests pass.

--- a/src/components/ui/Textarea.tsx
+++ b/src/components/ui/Textarea.tsx
@@ -1,0 +1,120 @@
+"use client";
+
+import { useId, useState } from "react";
+import { Pencil, AlertCircle } from "lucide-react";
+
+const MAX = 200;
+
+type TextareaState = "default" | "focus" | "filled" | "error";
+
+interface TextareaProps {
+  /** Controlled value */
+  value?: string;
+  /** onChange handler (controlled usage) */
+  onChange?: (e: React.ChangeEvent<HTMLTextAreaElement>) => void;
+  /** Force a specific visual state; omit for automatic behaviour */
+  state?: TextareaState;
+  /** Label text shown above the textarea */
+  label?: string;
+  /** Maximum character count */
+  maxLength?: number;
+}
+
+export function Textarea({
+  value: valueProp,
+  onChange,
+  state: forcedState,
+  label = "Description",
+  maxLength = MAX,
+}: TextareaProps) {
+  const id = useId();
+  const descId = `${id}-desc`;
+  const errorId = `${id}-error`;
+
+  const [internalValue, setInternalValue] = useState("");
+  const [focused, setFocused] = useState(false);
+
+  const isControlled = valueProp !== undefined;
+  const value = isControlled ? valueProp : internalValue;
+  const count = value.length;
+  const atLimit = count >= maxLength;
+
+  // Derive visual state
+  const state: TextareaState =
+    forcedState ??
+    (atLimit
+      ? "error"
+      : focused
+      ? "focus"
+      : value.length > 0
+      ? "filled"
+      : "default");
+
+  const isError = state === "error";
+  const isFilled = state === "filled";
+
+  const borderClass = isError
+    ? "border-[#DC2626] focus:outline-none"
+    : state === "focus"
+    ? "border-indigo-500 focus:outline-none"
+    : "border-[#E2E8F0] focus:outline-none";
+
+  const textClass = isError
+    ? "text-[#DC2626]"
+    : isFilled
+    ? "text-[#94A3B8]"
+    : "text-[#0F172A]";
+
+  function handleChange(e: React.ChangeEvent<HTMLTextAreaElement>) {
+    if (!isControlled) setInternalValue(e.target.value);
+    onChange?.(e);
+  }
+
+  return (
+    <div className="flex flex-col gap-1 font-[Inter,system-ui,sans-serif]">
+      {/* Label */}
+      <label
+        htmlFor={id}
+        className="flex items-center gap-1.5 text-[12px] font-medium text-[#475569]"
+      >
+        <Pencil size={12} aria-hidden="true" />
+        {label}
+      </label>
+
+      {/* Textarea */}
+      <textarea
+        id={id}
+        value={value}
+        onChange={handleChange}
+        onFocus={() => setFocused(true)}
+        onBlur={() => setFocused(false)}
+        maxLength={maxLength}
+        placeholder="Write description here..."
+        rows={4}
+        aria-describedby={isError ? errorId : descId}
+        aria-invalid={isError}
+        className={[
+          "w-full resize-none rounded-lg border bg-white px-3 py-2 text-[16px] placeholder-[#94A3B8] transition-colors",
+          borderClass,
+          textClass,
+        ].join(" ")}
+      />
+
+      {/* Helper / Error row */}
+      {isError ? (
+        <p
+          id={errorId}
+          role="alert"
+          className="flex items-center gap-1 text-[12px] text-[#DC2626]"
+        >
+          <AlertCircle size={12} aria-hidden="true" />
+          Reached the {maxLength} text limit
+        </p>
+      ) : (
+        <p id={descId} className="text-[12px] text-[#475569]">
+          {count}/{maxLength} — Max {maxLength} texts
+        </p>
+      )}
+    </div>
+  );
+}

--- a/tests/Textarea.test.tsx
+++ b/tests/Textarea.test.tsx
@@ -1,0 +1,58 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import { describe, it, expect } from "vitest";
+import { Textarea } from "@/components/ui/Textarea";
+
+describe("Textarea", () => {
+  it("renders label with pencil icon and placeholder in default state", () => {
+    render(<Textarea />);
+    expect(screen.getByLabelText("Description")).toBeInTheDocument();
+    expect(
+      screen.getByPlaceholderText("Write description here...")
+    ).toBeInTheDocument();
+    expect(screen.getByText(/Max 200 texts/)).toBeInTheDocument();
+  });
+
+  it("shows indigo border class when state='focus' is forced", () => {
+    render(<Textarea state="focus" value="hello" onChange={() => {}} />);
+    const ta = screen.getByRole("textbox");
+    expect(ta.className).toMatch(/border-indigo-500/);
+  });
+
+  it("shows faded text class when state='filled' is forced", () => {
+    render(<Textarea state="filled" value="some text" onChange={() => {}} />);
+    const ta = screen.getByRole("textbox");
+    expect(ta.className).toMatch(/text-\[#94A3B8\]/);
+  });
+
+  it("shows error state and alert when state='error' is forced", () => {
+    render(<Textarea state="error" value="x" onChange={() => {}} />);
+    const ta = screen.getByRole("textbox");
+    expect(ta.className).toMatch(/border-\[#DC2626\]/);
+    expect(ta).toHaveAttribute("aria-invalid", "true");
+    expect(screen.getByRole("alert")).toHaveTextContent(
+      "Reached the 200 text limit"
+    );
+  });
+
+  it("automatically enters error state when character count reaches max", () => {
+    const longText = "a".repeat(200);
+    render(<Textarea value={longText} onChange={() => {}} />);
+    expect(screen.getByRole("alert")).toBeInTheDocument();
+  });
+
+  it("updates character count live as user types", () => {
+    render(<Textarea />);
+    const ta = screen.getByRole("textbox");
+    fireEvent.change(ta, { target: { value: "Hello" } });
+    expect(screen.getByText(/5\/200/)).toBeInTheDocument();
+  });
+
+  it("associates label, helper text and error message accessibly", () => {
+    render(<Textarea />);
+    const ta = screen.getByRole("textbox");
+    // aria-describedby points to helper when not in error
+    const descId = ta.getAttribute("aria-describedby");
+    expect(descId).toBeTruthy();
+    expect(document.getElementById(descId!)).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
# feat: labelled Textarea with character-limit indicator

## Summary
Implements the `Textarea` UI component per `docs/design/design_system.md`.

## Changes
- `src/components/ui/Textarea.tsx` — new component
- `tests/Textarea.test.tsx` — 7 tests (all passing)

## States
| State | Trigger |
|---|---|
| Default | No value, not focused |
| Focus/Active | `state="focus"` prop or textarea focused |
| Filled/Inactive | `state="filled"` prop or has value, not focused |
| Error | `state="error"` prop or character count reaches `maxLength` (200) |

## Acceptance Criteria
- [x] All four states reachable via `state` prop
- [x] Live character count vs. max (200) displayed as `n/200`
- [x] Accessible: `aria-describedby`, `aria-invalid`, `role="alert"`, `htmlFor` label association

## Testing
```bash
pnpm test tests/Textarea.test.tsx
```
All 7 tests pass.

closes #165 
