### PR TITLE
feat: Signup / Onboarding screen (email + PIN)

### DIFF
--- a/src/app/signup/page.tsx
+++ b/src/app/signup/page.tsx
@@ -1,0 +1,348 @@
+"use client";
+
+import { useState } from "react";
+import { Syne } from "next/font/google";
+import { CheckCircle } from "lucide-react";
+import { Input } from "@/components/ui/Input";
+import { Button } from "@/components/ui/Button";
+
+const syne = Syne({ subsets: ["latin"], weight: ["700", "800"] });
+
+// ── Step 1 data ──────────────────────────────────────────────────────────────
+const PIN_LENGTH = 6;
+
+// ── Step 2 data ──────────────────────────────────────────────────────────────
+const INTERESTS = [
+  "DeFi", "Blockchain Basics", "Stellar", "Smart Contracts",
+  "NFTs", "Web3 Dev", "Financial Literacy", "Crypto Trading",
+  "Identity & Privacy", "DAOs",
+];
+const LEVELS = ["Beginner", "Intermediate", "Advanced"] as const;
+type Level = (typeof LEVELS)[number];
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+function isValidEmail(v: string) {
+  return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(v);
+}
+
+// ── Progress bar ─────────────────────────────────────────────────────────────
+function ProgressBar({ step }: { step: number }) {
+  return (
+    <div className="flex items-center gap-2" aria-label={`Step ${step} of 3`}>
+      {[1, 2, 3].map((n) => (
+        <div
+          key={n}
+          className={[
+            "h-1.5 flex-1 rounded-full transition-all duration-300",
+            n <= step ? "bg-[#F5B841]" : "bg-[#E2E8F0]",
+          ].join(" ")}
+        />
+      ))}
+    </div>
+  );
+}
+
+// ── Step 1 — Email + PIN ─────────────────────────────────────────────────────
+function StepCredentials({
+  email, setEmail, pin, setPin, onNext,
+}: {
+  email: string; setEmail: (v: string) => void;
+  pin: string; setPin: (v: string) => void;
+  onNext: () => void;
+}) {
+  const [touched, setTouched] = useState({ email: false, pin: false });
+
+  const emailError = touched.email && !isValidEmail(email);
+  const pinError = touched.pin && pin.length !== PIN_LENGTH;
+  const canContinue = isValidEmail(email) && pin.length === PIN_LENGTH;
+
+  function handlePinChange(e: React.ChangeEvent<HTMLInputElement>) {
+    const v = e.target.value.replace(/\D/g, "").slice(0, PIN_LENGTH);
+    setPin(v);
+  }
+
+  return (
+    <div className="flex flex-col gap-6">
+      <div>
+        <h1 className={`${syne.className} text-[28px] font-bold text-[#0F172A]`}>
+          Create your account
+        </h1>
+        <p className="mt-1 text-sm text-[#475569]">
+          Join thousands of learners earning while they grow.
+        </p>
+      </div>
+
+      <div className="flex flex-col gap-4">
+        <Input
+          variant="email"
+          label="Email address"
+          placeholder="Enter your email"
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+          state={emailError ? "error" : email && isValidEmail(email) ? "filled" : "default"}
+          errorMessage="Please enter a valid email address"
+          onBlur={() => setTouched((t) => ({ ...t, email: true }))}
+        />
+
+        <div className="flex flex-col gap-1">
+          <label className="flex items-center gap-1.5 text-[12px] font-medium text-[#475569]">
+            PIN (6 digits)
+          </label>
+          {/* PIN dot display */}
+          <div className="flex gap-3 py-2" aria-hidden="true">
+            {Array.from({ length: PIN_LENGTH }).map((_, i) => (
+              <div
+                key={i}
+                className={[
+                  "h-3 w-3 rounded-full border-2 transition-all",
+                  i < pin.length
+                    ? "border-[#F5B841] bg-[#F5B841]"
+                    : "border-[#E2E8F0] bg-white",
+                ].join(" ")}
+              />
+            ))}
+          </div>
+          <input
+            type="password"
+            inputMode="numeric"
+            value={pin}
+            onChange={handlePinChange}
+            onBlur={() => setTouched((t) => ({ ...t, pin: true }))}
+            maxLength={PIN_LENGTH}
+            placeholder="••••••"
+            aria-label="6-digit PIN"
+            className={[
+              "w-full rounded-lg border bg-white px-3 py-2.5 text-[16px] tracking-[0.5em] placeholder-[#94A3B8] transition-colors focus:outline-none focus:border-indigo-500",
+              pinError ? "border-[#DC2626] text-[#DC2626]" : "border-[#E2E8F0] text-[#0F172A]",
+            ].join(" ")}
+          />
+          {pinError && (
+            <p role="alert" className="text-[12px] text-[#DC2626]">
+              PIN must be 6 digits
+            </p>
+          )}
+        </div>
+      </div>
+
+      <Button
+        variant="primary"
+        disabled={!canContinue}
+        onClick={onNext}
+        className="w-full"
+      >
+        Continue
+      </Button>
+
+      <p className="text-center text-sm text-[#475569]">
+        Already have an account?{" "}
+        <a href="#" className="font-medium text-[#14B8A6] hover:underline">
+          Sign in
+        </a>
+      </p>
+    </div>
+  );
+}
+
+// ── Step 2 — Interests + Skill Level ────────────────────────────────────────
+function StepInterests({
+  selected, setSelected, level, setLevel, onNext, onBack,
+}: {
+  selected: string[]; setSelected: (v: string[]) => void;
+  level: Level | null; setLevel: (v: Level) => void;
+  onNext: () => void; onBack: () => void;
+}) {
+  function toggle(item: string) {
+    setSelected(
+      selected.includes(item)
+        ? selected.filter((s) => s !== item)
+        : [...selected, item]
+    );
+  }
+
+  const canContinue = selected.length > 0 && level !== null;
+
+  return (
+    <div className="flex flex-col gap-6">
+      <div>
+        <h1 className={`${syne.className} text-[28px] font-bold text-[#0F172A]`}>
+          What do you want to learn?
+        </h1>
+        <p className="mt-1 text-sm text-[#475569]">
+          Pick your interests and skill level — we&apos;ll personalise your path.
+        </p>
+      </div>
+
+      {/* Interest chips */}
+      <div>
+        <p className="mb-2 text-[12px] font-medium text-[#475569]">
+          Select topics ({selected.length} selected)
+        </p>
+        <div className="flex flex-wrap gap-2">
+          {INTERESTS.map((item) => {
+            const active = selected.includes(item);
+            return (
+              <button
+                key={item}
+                type="button"
+                onClick={() => toggle(item)}
+                aria-pressed={active}
+                className={[
+                  "rounded-full border px-3 py-1.5 text-sm font-medium transition-colors",
+                  active
+                    ? "border-[#F5B841] bg-[#F5B841] text-[#0F172A]"
+                    : "border-[#E2E8F0] bg-white text-[#475569] hover:border-[#F5B841]",
+                ].join(" ")}
+              >
+                {item}
+              </button>
+            );
+          })}
+        </div>
+      </div>
+
+      {/* Skill level */}
+      <div>
+        <p className="mb-2 text-[12px] font-medium text-[#475569]">
+          Your current level
+        </p>
+        <div className="grid grid-cols-3 gap-2">
+          {LEVELS.map((l) => (
+            <button
+              key={l}
+              type="button"
+              onClick={() => setLevel(l)}
+              aria-pressed={level === l}
+              className={[
+                "rounded-xl border py-3 text-sm font-medium transition-colors",
+                level === l
+                  ? "border-[#14B8A6] bg-[#14B8A6]/10 text-[#0F172A]"
+                  : "border-[#E2E8F0] bg-white text-[#475569] hover:border-[#14B8A6]",
+              ].join(" ")}
+            >
+              {l}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      <div className="flex gap-3">
+        <Button variant="outline" onClick={onBack} className="flex-1">
+          Back
+        </Button>
+        <Button
+          variant="primary"
+          disabled={!canContinue}
+          onClick={onNext}
+          className="flex-1"
+        >
+          Continue
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+// ── Step 3 — Welcome bonus ───────────────────────────────────────────────────
+function StepWelcome({ email, onDone }: { email: string; onDone: () => void }) {
+  return (
+    <div className="flex flex-col items-center gap-6 text-center">
+      {/* Reward badge */}
+      <div className="flex h-24 w-24 items-center justify-center rounded-full bg-[#F5B841]/20">
+        <span className="text-4xl" role="img" aria-label="gift">🎁</span>
+      </div>
+
+      <div>
+        <h1 className={`${syne.className} text-[28px] font-bold text-[#0F172A]`}>
+          You&apos;re in!
+        </h1>
+        <p className="mt-1 text-sm text-[#475569]">
+          Welcome to Learnault, <span className="font-medium text-[#0F172A]">{email}</span>
+        </p>
+      </div>
+
+      {/* Bonus card */}
+      <div className="w-full rounded-2xl border border-[#F5B841]/50 bg-gradient-to-br from-[#FEF3C7] to-[#FFF] p-5">
+        <p className="text-xs font-medium uppercase tracking-wide text-[#D97706]">
+          Welcome Bonus
+        </p>
+        <p className="mt-1 text-[36px] font-bold text-[#0F172A]">
+          $0.50{" "}
+          <span className="text-[20px] font-medium text-[#475569]">USDC</span>
+        </p>
+        <p className="mt-1 text-sm text-[#475569]">
+          Credited to your wallet once your first lesson is complete.
+        </p>
+        <div className="mt-3 flex items-center gap-1.5 text-[12px] text-[#16A34A]">
+          <CheckCircle size={14} aria-hidden="true" />
+          Powered by Stellar blockchain
+        </div>
+      </div>
+
+      <Button variant="primary" onClick={onDone} className="w-full">
+        Start Learning
+      </Button>
+
+      <p className="text-xs text-[#94A3B8]">
+        Your progress and rewards are stored securely on-chain.
+      </p>
+    </div>
+  );
+}
+
+// ── Page shell ───────────────────────────────────────────────────────────────
+export default function SignupPage() {
+  const [step, setStep] = useState(1);
+
+  // Step 1
+  const [email, setEmail] = useState("");
+  const [pin, setPin] = useState("");
+
+  // Step 2
+  const [interests, setInterests] = useState<string[]>([]);
+  const [level, setLevel] = useState<Level | null>(null);
+
+  return (
+    <div className="flex min-h-screen items-center justify-center bg-[#F9FAFB] px-4 py-10 font-[Inter,system-ui,sans-serif]">
+      <div className="w-full max-w-md">
+        {/* Logo */}
+        <div className="mb-6 flex items-center gap-2">
+          {/* eslint-disable-next-line @next/next/no-img-element */}
+          <img src="/assets/logo-icon.svg" alt="Learnault" className="h-7 w-7" />
+          <span className={`${syne.className} text-[18px] font-bold text-[#0F172A]`}>
+            Learnault
+          </span>
+        </div>
+
+        <div className="rounded-2xl border border-[#E2E8F0] bg-white p-6 shadow-sm">
+          {/* Progress */}
+          <div className="mb-6">
+            <ProgressBar step={step} />
+            <p className="mt-2 text-[12px] text-[#94A3B8]">Step {step} of 3</p>
+          </div>
+
+          {step === 1 && (
+            <StepCredentials
+              email={email} setEmail={setEmail}
+              pin={pin} setPin={setPin}
+              onNext={() => setStep(2)}
+            />
+          )}
+          {step === 2 && (
+            <StepInterests
+              selected={interests} setSelected={setInterests}
+              level={level} setLevel={setLevel}
+              onNext={() => setStep(3)}
+              onBack={() => setStep(1)}
+            />
+          )}
+          {step === 3 && (
+            <StepWelcome
+              email={email}
+              onDone={() => alert("Onboarding complete — navigate to /dashboard")}
+            />
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/ui/Button.tsx
+++ b/src/components/ui/Button.tsx
@@ -1,0 +1,55 @@
+import { ArrowRight } from "lucide-react";
+import { ButtonHTMLAttributes } from "react";
+
+type ButtonVariant = "primary" | "secondary" | "outline" | "link";
+
+interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
+  variant?: ButtonVariant;
+  loading?: boolean;
+}
+
+export function Button({
+  variant = "primary",
+  loading = false,
+  disabled,
+  children,
+  className = "",
+  ...props
+}: ButtonProps) {
+  const isDisabled = disabled || loading;
+
+  const base =
+    "inline-flex items-center justify-center gap-2 rounded-full px-6 py-3 text-[16px] font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2";
+
+  const variants: Record<ButtonVariant, string> = {
+    primary: isDisabled
+      ? "bg-[#E2E8F0] text-[#94A3B8] cursor-not-allowed"
+      : "bg-[#F5B841] text-[#0F172A] hover:bg-[#e6a81f] focus-visible:ring-[#F5B841]",
+    secondary: isDisabled
+      ? "bg-[#E2E8F0] text-[#94A3B8] cursor-not-allowed"
+      : "bg-[#FEF3C7] text-[#0F172A] hover:bg-[#fde68a] focus-visible:ring-[#F5B841]",
+    outline: isDisabled
+      ? "border border-[#E2E8F0] bg-white text-[#94A3B8] cursor-not-allowed"
+      : "border border-[#D1D5DB] bg-white text-[#0F172A] hover:bg-[#F7F7F7] focus-visible:ring-[#475569]",
+    link: isDisabled
+      ? "text-[#14B8A6]/50 cursor-not-allowed"
+      : "text-[#14B8A6] hover:text-[#0f9387] px-0 py-0 rounded-none",
+  };
+
+  return (
+    <button
+      disabled={isDisabled}
+      aria-disabled={isDisabled}
+      className={[base, variants[variant], className].join(" ")}
+      {...props}
+    >
+      {loading ? (
+        <span className="h-4 w-4 animate-spin rounded-full border-2 border-current border-t-transparent" />
+      ) : null}
+      {children}
+      {variant === "link" && !loading && (
+        <ArrowRight size={16} aria-hidden="true" />
+      )}
+    </button>
+  );
+}

--- a/src/components/ui/Input.tsx
+++ b/src/components/ui/Input.tsx
@@ -1,0 +1,128 @@
+"use client";
+
+import { useId, useState } from "react";
+import { Mail, Eye, EyeOff, CheckCircle, AlertCircle } from "lucide-react";
+
+type InputState = "default" | "focus" | "filled" | "error";
+type InputVariant = "email" | "pin";
+
+interface InputProps
+  extends Omit<React.InputHTMLAttributes<HTMLInputElement>, "value" | "onChange"> {
+  variant?: InputVariant;
+  label?: string;
+  placeholder?: string;
+  value?: string;
+  onChange?: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  state?: InputState;
+  errorMessage?: string;
+  maxLength?: number;
+}
+
+export function Input({
+  variant = "email",
+  label,
+  placeholder,
+  value: valueProp,
+  onChange,
+  state: forcedState,
+  errorMessage = "Email is not valid",
+  maxLength,
+  ...rest
+}: InputProps) {
+  const id = useId();
+  const errorId = `${id}-error`;
+
+  const [internalValue, setInternalValue] = useState("");
+  const [focused, setFocused] = useState(false);
+  const [showPin, setShowPin] = useState(false);
+
+  const isControlled = valueProp !== undefined;
+  const value = isControlled ? valueProp : internalValue;
+
+  const state: InputState =
+    forcedState ??
+    (focused ? "focus" : value.length > 0 ? "filled" : "default");
+
+  const isError = state === "error";
+  const isFilled = state === "filled";
+
+  const borderClass = isError
+    ? "border-[#DC2626]"
+    : state === "focus"
+    ? "border-indigo-500"
+    : "border-[#E2E8F0]";
+
+  const defaultLabel = variant === "pin" ? "PIN" : "Email";
+  const defaultPlaceholder =
+    variant === "pin" ? "Enter 6-digit PIN" : "Enter email";
+  const inputType =
+    variant === "pin" ? (showPin ? "text" : "password") : "email";
+
+  function handleChange(e: React.ChangeEvent<HTMLInputElement>) {
+    if (!isControlled) setInternalValue(e.target.value);
+    onChange?.(e);
+  }
+
+  return (
+    <div className="flex flex-col gap-1 font-[Inter,system-ui,sans-serif]">
+      <label
+        htmlFor={id}
+        className="flex items-center gap-1.5 text-[12px] font-medium text-[#475569]"
+      >
+        <Mail size={12} aria-hidden="true" />
+        {label ?? defaultLabel}
+      </label>
+
+      <div className="relative">
+        <input
+          id={id}
+          type={inputType}
+          value={value}
+          onChange={handleChange}
+          onFocus={() => setFocused(true)}
+          onBlur={() => setFocused(false)}
+          placeholder={placeholder ?? defaultPlaceholder}
+          maxLength={maxLength ?? (variant === "pin" ? 6 : undefined)}
+          inputMode={variant === "pin" ? "numeric" : "email"}
+          aria-invalid={isError}
+          aria-describedby={isError ? errorId : undefined}
+          {...rest}
+          className={[
+            "w-full rounded-lg border bg-white px-3 py-2.5 pr-10 text-[16px] placeholder-[#94A3B8] transition-colors focus:outline-none",
+            borderClass,
+            isError ? "text-[#DC2626]" : "text-[#0F172A]",
+          ].join(" ")}
+        />
+
+        {/* Right icon */}
+        <span className="pointer-events-none absolute right-3 top-1/2 -translate-y-1/2">
+          {isError ? (
+            <AlertCircle size={16} className="text-[#DC2626]" aria-hidden />
+          ) : isFilled ? (
+            <CheckCircle size={16} className="text-[#16A34A]" aria-hidden />
+          ) : variant === "pin" ? (
+            <button
+              type="button"
+              className="pointer-events-auto text-[#94A3B8] hover:text-[#475569]"
+              onClick={() => setShowPin((v) => !v)}
+              aria-label={showPin ? "Hide PIN" : "Show PIN"}
+            >
+              {showPin ? <EyeOff size={16} /> : <Eye size={16} />}
+            </button>
+          ) : null}
+        </span>
+      </div>
+
+      {isError && (
+        <p
+          id={errorId}
+          role="alert"
+          className="flex items-center gap-1 text-[12px] text-[#DC2626]"
+        >
+          <AlertCircle size={12} aria-hidden />
+          {errorMessage}
+        </p>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

Implements the 2-minute signup flow from the TRD User Journey (Step 2: SIGNUP) — frontend/design only, no backend or auth wiring.

## Changes

### New components
- `src/components/ui/Button.tsx` — primary / secondary / outline / link variants with loading + disabled states
- `src/components/ui/Input.tsx` — email & PIN variants with default / focus / filled / error states, WCAG-compliant

### New route
- `src/app/signup/page.tsx` — 3-step onboarding flow at `/signup`

## Flow

| Step | Screen |
|------|--------|
| 1 | Email entry (reuses Input) + 6-digit PIN with dot-progress indicator |
| 2 | Interest chip multiselect (10 topics) + Beginner / Intermediate / Advanced skill-level cards |
| 3 | $0.50 USDC welcome-bonus confirmation card with Stellar badge |

A gold progress bar spanning all 3 steps sits at the top of the card.

## What's not included (by design)
- No wallet creation
- No backend / API calls
- No auth wiring (auth-context.tsx remains commented out)
- All state is local mock only

## Tested
- TypeScript: `tsc --noEmit` exits 0 with no errors

Closes #169