### PR TITLE
UI: Learner dashboard & profile

### DIFF
--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -1,0 +1,140 @@
+import { ProfileHeader } from "@/components/dashboard/ProfileHeader";
+import { StreakIndicator } from "@/components/dashboard/StreakIndicator";
+import { EarningsSnapshot } from "@/components/dashboard/EarningsSnapshot";
+import { ProgressSnapshot } from "@/components/dashboard/ProgressSnapshot";
+import { ContinueLearning } from "@/components/dashboard/ContinueLearning";
+import { RecommendedPaths } from "@/components/dashboard/RecommendedPaths";
+
+const MOCK_USER = {
+  name: "Alex Rivera",
+  email: "alex.rivera@example.com",
+  bio: "Web3 enthusiast learning Stellar blockchain development. Passionate about decentralized finance and building financial tools for emerging markets.",
+  joinDate: "March 2026",
+};
+
+const MOCK_STREAK = {
+  currentStreak: 7,
+  longestStreak: 14,
+  bonusMultiplier: 1.5,
+  weeklyLog: [true, true, true, true, true, false, false],
+};
+
+const MOCK_EARNINGS = {
+  totalUsdc: "12.50",
+  weekUsdc: "2.25",
+  monthUsdc: "8.75",
+  totalXlm: "45",
+  walletConnected: true,
+};
+
+const MOCK_PROGRESS = {
+  completedCourses: 3,
+  totalCourses: 8,
+  overallPercent: 38,
+  badges: [
+    { label: "Stellar Scholar", icon: "award" },
+    { label: "First Quiz", icon: "award" },
+    { label: "Week Warrior", icon: "award" },
+  ],
+};
+
+const MOCK_MODULES = [
+  {
+    title: "Introduction to Stellar",
+    progress: 75,
+    reward: "$0.25 USDC",
+    estimatedTime: "15 min",
+    tier: "Tier 1",
+  },
+  {
+    title: "Stellar Consensus Protocol",
+    progress: 30,
+    reward: "$0.50 USDC",
+    estimatedTime: "20 min",
+    tier: "Tier 1",
+  },
+  {
+    title: "Building with Soroban",
+    progress: 10,
+    reward: "$1.00 USDC",
+    estimatedTime: "30 min",
+    tier: "Tier 2",
+  },
+];
+
+const MOCK_PATHS = [
+  {
+    title: "Stellar Basics",
+    description:
+      "Master wallets, transactions, and the Stellar Consensus Protocol.",
+    reward: "80 XLM",
+    difficulty: "Beginner",
+    duration: "4 hours",
+  },
+  {
+    title: "Stellar Integration",
+    description:
+      "Connect to Horizon, use the Stellar SDK, and build Soroban contracts.",
+    reward: "120 XLM",
+    difficulty: "Intermediate",
+    duration: "3 hours",
+  },
+  {
+    title: "Scale node to L2",
+    description:
+      "Deploy production-grade infrastructure and bridge Stellar assets to L2.",
+    reward: "540 XLM",
+    difficulty: "Advanced",
+    duration: "7 hours",
+  },
+];
+
+export const metadata = {
+  title: "Dashboard — Learnault",
+  description: "Your learning journey at a glance",
+};
+
+export default function DashboardPage() {
+  return (
+    <div className="min-h-screen bg-background">
+      <div className="mx-auto max-w-6xl px-4 py-8 sm:px-6 lg:py-10">
+        <ProfileHeader
+          name={MOCK_USER.name}
+          email={MOCK_USER.email}
+          bio={MOCK_USER.bio}
+          joinDate={MOCK_USER.joinDate}
+          className="mb-6"
+        />
+
+        <div className="mb-6 grid gap-6 sm:grid-cols-2">
+          <StreakIndicator
+            currentStreak={MOCK_STREAK.currentStreak}
+            longestStreak={MOCK_STREAK.longestStreak}
+            bonusMultiplier={MOCK_STREAK.bonusMultiplier}
+            weeklyLog={MOCK_STREAK.weeklyLog}
+          />
+          <EarningsSnapshot
+            totalUsdc={MOCK_EARNINGS.totalUsdc}
+            weekUsdc={MOCK_EARNINGS.weekUsdc}
+            monthUsdc={MOCK_EARNINGS.monthUsdc}
+            totalXlm={MOCK_EARNINGS.totalXlm}
+            walletConnected={MOCK_EARNINGS.walletConnected}
+          />
+        </div>
+
+        <ProgressSnapshot
+          completedCourses={MOCK_PROGRESS.completedCourses}
+          totalCourses={MOCK_PROGRESS.totalCourses}
+          overallPercent={MOCK_PROGRESS.overallPercent}
+          badges={MOCK_PROGRESS.badges}
+          className="mb-6"
+        />
+
+        <div className="grid gap-6 lg:grid-cols-2">
+          <ContinueLearning modules={MOCK_MODULES} />
+          <RecommendedPaths paths={MOCK_PATHS} />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/dashboard/ContinueLearning.tsx
+++ b/src/components/dashboard/ContinueLearning.tsx
@@ -1,0 +1,93 @@
+"use client";
+
+import { BookOpen, ChevronRight, Clock } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+
+interface Module {
+  title: string;
+  progress: number;
+  reward: string;
+  estimatedTime: string;
+  tier: string;
+}
+
+interface ContinueLearningProps {
+  modules: Module[];
+  className?: string;
+}
+
+function ModuleCard({ module }: { module: Module }) {
+  return (
+    <div className="rounded-xl border bg-card p-4 shadow-sm transition hover:shadow-md">
+      <div className="flex items-start justify-between gap-3">
+        <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-primary/10">
+          <BookOpen className="h-5 w-5 text-primary" />
+        </div>
+        <span className="rounded-full bg-primary/10 px-2.5 py-0.5 text-[11px] font-medium text-primary">
+          {module.tier}
+        </span>
+      </div>
+
+      <h3 className="mt-3 text-sm font-semibold text-foreground">
+        {module.title}
+      </h3>
+
+      <div className="mt-3">
+        <div className="flex items-center justify-between text-xs text-muted-foreground">
+          <span>{module.progress}% complete</span>
+        </div>
+        <div className="mt-1 h-1.5 w-full overflow-hidden rounded-full bg-muted">
+          <div
+            className="h-full rounded-full bg-primary transition-all duration-500"
+            style={{ width: `${module.progress}%` }}
+          />
+        </div>
+      </div>
+
+      <div className="mt-3 flex items-center justify-between">
+        <div className="flex items-center gap-3 text-xs text-muted-foreground">
+          <span className="inline-flex items-center gap-1">
+            <Clock className="h-3.5 w-3.5" aria-hidden="true" />
+            {module.estimatedTime}
+          </span>
+          <span className="font-medium text-primary">+{module.reward}</span>
+        </div>
+        <button
+          type="button"
+          className="inline-flex items-center gap-0.5 text-xs font-semibold text-primary transition hover:text-secondary"
+        >
+          Continue
+          <ChevronRight className="h-3.5 w-3.5" aria-hidden="true" />
+        </button>
+      </div>
+    </div>
+  );
+}
+
+export function ContinueLearning({
+  modules,
+  className,
+}: ContinueLearningProps) {
+  return (
+    <div className={cn("rounded-2xl border bg-card p-5 shadow-sm sm:p-6", className)}>
+      <div className="flex items-center justify-between">
+        <p className="text-xs font-medium uppercase tracking-wider text-muted-foreground">
+          Continue Learning
+        </p>
+        <button
+          type="button"
+          className="text-xs font-medium text-primary transition hover:text-secondary"
+        >
+          View all
+        </button>
+      </div>
+
+      <div className="mt-4 space-y-3">
+        {modules.map((module) => (
+          <ModuleCard key={module.title} module={module} />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/components/dashboard/EarningsSnapshot.tsx
+++ b/src/components/dashboard/EarningsSnapshot.tsx
@@ -1,0 +1,96 @@
+"use client";
+
+import { TrendingUp, Wallet } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+interface EarningsSnapshotProps {
+  totalUsdc: string;
+  weekUsdc: string;
+  monthUsdc: string;
+  totalXlm: string;
+  walletConnected: boolean;
+  className?: string;
+}
+
+export function EarningsSnapshot({
+  totalUsdc,
+  weekUsdc,
+  monthUsdc,
+  totalXlm,
+  walletConnected,
+  className,
+}: EarningsSnapshotProps) {
+  return (
+    <div
+      className={cn(
+        "rounded-2xl border bg-card p-5 shadow-sm sm:p-6",
+        className,
+      )}
+    >
+      <div className="flex items-center justify-between">
+        <p className="text-xs font-medium uppercase tracking-wider text-muted-foreground">
+          Earnings
+        </p>
+        <span
+          className={cn(
+            "inline-flex items-center gap-1 rounded-full px-2.5 py-0.5 text-[11px] font-medium",
+            walletConnected
+              ? "bg-green-50 text-green-700"
+              : "bg-muted text-muted-foreground",
+          )}
+        >
+          <span
+            className={cn(
+              "h-1.5 w-1.5 rounded-full",
+              walletConnected ? "bg-green-500" : "bg-muted-foreground",
+            )}
+          />
+          {walletConnected ? "Wallet connected" : "No wallet"}
+        </span>
+      </div>
+
+      <div className="mt-4">
+        <div className="flex items-baseline gap-1.5">
+          <span className="text-3xl font-bold text-foreground">
+            {totalUsdc}
+          </span>
+          <span className="text-sm font-medium text-muted-foreground">
+            USDC
+          </span>
+        </div>
+        <p className="mt-0.5 text-sm text-muted-foreground">
+          +{totalXlm} XLM earned
+        </p>
+      </div>
+
+      <div className="mt-5 grid grid-cols-2 gap-3">
+        <div className="rounded-xl bg-muted p-3">
+          <div className="flex items-center gap-1.5 text-xs text-muted-foreground">
+            <TrendingUp className="h-3.5 w-3.5" aria-hidden="true" />
+            This week
+          </div>
+          <p className="mt-1 text-sm font-semibold text-foreground">
+            +{weekUsdc} USDC
+          </p>
+        </div>
+        <div className="rounded-xl bg-muted p-3">
+          <div className="flex items-center gap-1.5 text-xs text-muted-foreground">
+            <TrendingUp className="h-3.5 w-3.5" aria-hidden="true" />
+            This month
+          </div>
+          <p className="mt-1 text-sm font-semibold text-foreground">
+            +{monthUsdc} USDC
+          </p>
+        </div>
+      </div>
+
+      <button
+        type="button"
+        className="mt-4 inline-flex w-full items-center justify-center gap-2 rounded-xl border border-border bg-background px-4 py-2.5 text-sm font-medium text-foreground transition hover:bg-accent"
+      >
+        <Wallet className="h-4 w-4" aria-hidden="true" />
+        View Wallet
+      </button>
+    </div>
+  );
+}

--- a/src/components/dashboard/ProfileHeader.tsx
+++ b/src/components/dashboard/ProfileHeader.tsx
@@ -1,0 +1,76 @@
+"use client";
+
+import { Syne } from "next/font/google";
+import { Edit3 } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+const syne = Syne({ subsets: ["latin"], weight: ["700", "800"] });
+
+interface ProfileHeaderProps {
+  name: string;
+  email: string;
+  bio: string;
+  joinDate: string;
+  className?: string;
+}
+
+const initials = (name: string) =>
+  name
+    .split(" ")
+    .map((n) => n[0])
+    .join("")
+    .toUpperCase()
+    .slice(0, 2);
+
+export function ProfileHeader({
+  name,
+  email,
+  bio,
+  joinDate,
+  className,
+}: ProfileHeaderProps) {
+  return (
+    <div
+      className={cn(
+        "flex flex-wrap items-start gap-5 rounded-2xl border bg-card p-5 shadow-sm sm:p-6",
+        className,
+      )}
+    >
+      <div className="flex h-16 w-16 shrink-0 items-center justify-center rounded-full bg-primary text-xl font-bold text-primary-foreground sm:h-20 sm:w-20 sm:text-2xl">
+        {initials(name)}
+      </div>
+
+      <div className="min-w-0 flex-1">
+        <div className="flex flex-wrap items-start justify-between gap-3">
+          <div>
+            <h1
+              className={cn(
+                "text-xl font-bold text-foreground sm:text-2xl",
+                syne.className,
+              )}
+            >
+              {name}
+            </h1>
+            <p className="text-sm text-muted-foreground">{email}</p>
+          </div>
+          <button
+            type="button"
+            aria-label="Edit profile"
+            className="inline-flex items-center gap-1.5 rounded-full border border-border bg-background px-4 py-2 text-sm font-medium text-foreground transition hover:bg-accent"
+          >
+            <Edit3 className="h-4 w-4" aria-hidden="true" />
+            Edit
+          </button>
+        </div>
+
+        <p className="mt-3 text-sm leading-relaxed text-muted-foreground">
+          {bio}
+        </p>
+
+        <p className="mt-2 text-xs text-muted-foreground">
+          Joined {joinDate}
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/src/components/dashboard/ProgressSnapshot.tsx
+++ b/src/components/dashboard/ProgressSnapshot.tsx
@@ -1,0 +1,101 @@
+"use client";
+
+import { Award, BookOpen, Star } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+
+interface Badge {
+  label: string;
+  icon: string;
+}
+
+interface ProgressSnapshotProps {
+  completedCourses: number;
+  totalCourses: number;
+  overallPercent: number;
+  badges: Badge[];
+  className?: string;
+}
+
+export function ProgressSnapshot({
+  completedCourses,
+  totalCourses,
+  overallPercent,
+  badges,
+  className,
+}: ProgressSnapshotProps) {
+  return (
+    <div
+      className={cn(
+        "rounded-2xl border bg-card p-5 shadow-sm sm:p-6",
+        className,
+      )}
+    >
+      <p className="text-xs font-medium uppercase tracking-wider text-muted-foreground">
+        Your Progress
+      </p>
+
+      <div className="mt-4 flex flex-wrap items-center gap-6">
+        <div className="flex items-center gap-3">
+          <div className="flex h-12 w-12 items-center justify-center rounded-xl bg-primary/10">
+            <BookOpen className="h-6 w-6 text-primary" />
+          </div>
+          <div>
+            <p className="text-lg font-bold text-foreground">
+              {completedCourses}/{totalCourses}
+            </p>
+            <p className="text-xs text-muted-foreground">Courses</p>
+          </div>
+        </div>
+
+        <div className="h-10 w-px bg-border" />
+
+        <div className="flex items-center gap-3">
+          <div className="flex h-12 w-12 items-center justify-center rounded-xl bg-primary/10">
+            <Star className="h-6 w-6 text-primary" />
+          </div>
+          <div>
+            <p className="text-lg font-bold text-foreground">
+              {overallPercent}%
+            </p>
+            <p className="text-xs text-muted-foreground">Complete</p>
+          </div>
+        </div>
+      </div>
+
+      <div className="mt-5">
+        <div className="flex items-center justify-between text-sm">
+          <span className="text-muted-foreground">Overall completion</span>
+          <span className="font-semibold text-foreground">
+            {overallPercent}%
+          </span>
+        </div>
+        <div className="mt-2 h-2.5 w-full overflow-hidden rounded-full bg-muted">
+          <div
+            className="h-full rounded-full bg-primary transition-all duration-700"
+            style={{ width: `${overallPercent}%` }}
+          />
+        </div>
+      </div>
+
+      {badges.length > 0 && (
+        <div className="mt-5">
+          <p className="mb-2 text-xs font-medium text-muted-foreground">
+            Badges ({badges.length})
+          </p>
+          <div className="flex flex-wrap gap-2">
+            {badges.map((badge) => (
+              <span
+                key={badge.label}
+                className="inline-flex items-center gap-1 rounded-full bg-primary/10 px-3 py-1 text-xs font-medium text-primary"
+              >
+                <Award className="h-3.5 w-3.5" aria-hidden="true" />
+                {badge.label}
+              </span>
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/dashboard/RecommendedPaths.tsx
+++ b/src/components/dashboard/RecommendedPaths.tsx
@@ -1,0 +1,90 @@
+"use client";
+
+import { ChevronRight, Sparkles } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+
+interface Path {
+  title: string;
+  description: string;
+  reward: string;
+  difficulty: string;
+  duration: string;
+}
+
+interface RecommendedPathsProps {
+  paths: Path[];
+  className?: string;
+}
+
+const difficultyColor: Record<string, string> = {
+  Beginner: "text-green-600 bg-green-50",
+  Intermediate: "text-amber-600 bg-amber-50",
+  Advanced: "text-red-600 bg-red-50",
+};
+
+function PathCard({ path }: { path: Path }) {
+  return (
+    <div className="group rounded-xl border bg-card p-4 shadow-sm transition hover:border-primary/30 hover:shadow-md">
+      <div className="flex items-start justify-between gap-3">
+        <h3 className="text-sm font-semibold text-foreground">{path.title}</h3>
+        <span
+          className={cn(
+            "shrink-0 rounded-full px-2.5 py-0.5 text-[11px] font-medium",
+            difficultyColor[path.difficulty] ?? "bg-muted text-muted-foreground",
+          )}
+        >
+          {path.difficulty}
+        </span>
+      </div>
+
+      <p className="mt-2 text-xs leading-relaxed text-muted-foreground line-clamp-2">
+        {path.description}
+      </p>
+
+      <div className="mt-4 flex items-center justify-between">
+        <div className="flex items-center gap-3 text-xs text-muted-foreground">
+          <span className="inline-flex items-center gap-1">
+            <Sparkles className="h-3.5 w-3.5 text-primary" aria-hidden="true" />
+            <span className="font-medium text-primary">{path.reward}</span>
+          </span>
+          <span>{path.duration}</span>
+        </div>
+        <button
+          type="button"
+          className="inline-flex items-center gap-0.5 text-xs font-semibold text-primary transition hover:text-secondary"
+        >
+          Start
+          <ChevronRight className="h-3.5 w-3.5" aria-hidden="true" />
+        </button>
+      </div>
+    </div>
+  );
+}
+
+export function RecommendedPaths({
+  paths,
+  className,
+}: RecommendedPathsProps) {
+  return (
+    <div className={cn("rounded-2xl border bg-card p-5 shadow-sm sm:p-6", className)}>
+      <div className="flex items-center justify-between">
+        <p className="text-xs font-medium uppercase tracking-wider text-muted-foreground">
+          Recommended Paths
+        </p>
+        <button
+          type="button"
+          className="text-xs font-medium text-primary transition hover:text-secondary"
+        >
+          Browse all
+        </button>
+      </div>
+
+      <div className="mt-4 space-y-3">
+        {paths.map((path) => (
+          <PathCard key={path.title} path={path} />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/components/dashboard/StreakIndicator.tsx
+++ b/src/components/dashboard/StreakIndicator.tsx
@@ -1,0 +1,95 @@
+"use client";
+
+import { Flame } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+interface StreakIndicatorProps {
+  currentStreak: number;
+  longestStreak: number;
+  bonusMultiplier: number;
+  weeklyLog: boolean[];
+  className?: string;
+}
+
+const DAYS = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"];
+
+function getStreakTier(days: number): { label: string; color: string } {
+  if (days >= 30) return { label: "Legendary", color: "text-purple-600" };
+  if (days >= 21) return { label: "Diamond", color: "text-sky-500" };
+  if (days >= 14) return { label: "Gold", color: "text-amber-500" };
+  if (days >= 7) return { label: "Silver", color: "text-gray-400" };
+  if (days >= 3) return { label: "Bronze", color: "text-orange-600" };
+  return { label: "Starter", color: "text-muted-foreground" };
+}
+
+export function StreakIndicator({
+  currentStreak,
+  longestStreak,
+  bonusMultiplier,
+  weeklyLog,
+  className,
+}: StreakIndicatorProps) {
+  const tier = getStreakTier(currentStreak);
+
+  return (
+    <div
+      className={cn(
+        "rounded-2xl border bg-card p-5 shadow-sm sm:p-6",
+        className,
+      )}
+    >
+      <div className="flex items-start justify-between">
+        <div>
+          <p className="text-xs font-medium uppercase tracking-wider text-muted-foreground">
+            Daily Streak
+          </p>
+          <div className="mt-2 flex items-baseline gap-2">
+            <span className="text-3xl font-bold text-foreground">
+              {currentStreak}
+            </span>
+            <span className="text-sm text-muted-foreground">days</span>
+          </div>
+          <p className={cn("mt-1 text-sm font-medium", tier.color)}>
+            <Flame className="mr-1 inline h-4 w-4" aria-hidden="true" />
+            {tier.label}
+          </p>
+        </div>
+
+        <div className="flex flex-col items-end gap-1">
+          <div className="inline-flex items-center gap-1 rounded-full bg-primary/10 px-3 py-1 text-xs font-semibold text-primary">
+            <Flame className="h-3.5 w-3.5" aria-hidden="true" />
+            {bonusMultiplier}x earnings
+          </div>
+          <p className="text-xs text-muted-foreground">
+            Best: {longestStreak} days
+          </p>
+        </div>
+      </div>
+
+      <div className="mt-5">
+        <p className="mb-2 text-xs font-medium text-muted-foreground">
+          This week
+        </p>
+        <div className="flex gap-1.5">
+          {DAYS.map((day, i) => {
+            const active = weeklyLog[i] ?? false;
+            return (
+              <div key={day} className="flex flex-1 flex-col items-center gap-1">
+                <div
+                  className={cn(
+                    "h-8 w-full rounded-md transition-colors",
+                    active
+                      ? "bg-primary"
+                      : "bg-muted",
+                  )}
+                  aria-hidden="true"
+                />
+                <span className="text-[10px] text-muted-foreground">{day}</span>
+              </div>
+            );
+          })}
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

Designs the learner home dashboard tying the journey together. Frontend/design only with all mock data.

### New files

| File | Purpose |
|---|---|
| `src/app/dashboard/page.tsx` | Dashboard page shell with mock data and responsive grid layout |
| `src/components/dashboard/ProfileHeader.tsx` | Avatar initials, name, bio, join date, edit button |
| `src/components/dashboard/StreakIndicator.tsx` | Streak count (7), tier label (Silver), 1.5x bonus badge, 7-day calendar |
| `src/components/dashboard/EarningsSnapshot.tsx` | Total USDC/XLM, weekly/monthly breakdown, wallet status |
| `src/components/dashboard/ProgressSnapshot.tsx` | Course completion (3/8), 38% progress bar, 3 badges |
| `src/components/dashboard/ContinueLearning.tsx` | 3 in-progress module cards with progress bars and continue CTAs |
| `src/components/dashboard/RecommendedPaths.tsx` | 3 recommended path cards with difficulty tags and reward display |

### Layout

```
┌──────────────────────────────────────────────┐
│  ProfileHeader (avatar, name, bio, edit)       │
├──────────────────────┬───────────────────────┤
│  StreakIndicator     │  EarningsSnapshot       │
├──────────────────────┴───────────────────────┤
│  ProgressSnapshot                              │
├──────────────────────┬───────────────────────┤
│  ContinueLearning    │  RecommendedPaths       │
└──────────────────────┴───────────────────────┘
```

### Screenshot

<img width="1854" height="1476" alt="Dashboard-—-Learnault-06-29-2026_05_35_PM" src="https://github.com/user-attachments/assets/9cf49337-e0fe-426a-a09c-b9ae157635e1" />


### Acceptance Criteria

- [x] Cohesive dashboard composed from existing design patterns
- [x] Streak indicator with daily calendar and bonus multiplier visual (1.5x earnings)
- [x] Progress snapshot with completion bar and badge showcase
- [x] Responsive: 1-col mobile --> 2-col tablet --> full desktop grid
- [x] Mock data only, frontend-only, no auth dependency
- [x] Lint passes (0 errors, 0 new warnings), build succeeds

Closes #175