### PR TITLE
feat: Button component, login screen, and lesson view (Stellar Wave UI)

### DIFF
--- a/src/app/learn/page.tsx
+++ b/src/app/learn/page.tsx
@@ -1,0 +1,9 @@
+import { LessonView } from "@/components/learn/lesson-view";
+
+export default function LearnPage() {
+  return (
+    <main className="min-h-screen bg-[#F9FAFB]">
+      <LessonView />
+    </main>
+  );
+}

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -1,0 +1,118 @@
+"use client";
+
+import { useState } from "react";
+import { Input } from "@/components/ui/Input";
+import { Button } from "@/components/ui/Button";
+
+// Frontend/design only — no real authentication. Validation below is purely
+// visual; the commented-out auth-context mock is intentionally out of scope.
+const PIN_LENGTH = 6;
+
+function isValidEmail(v: string) {
+  return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(v);
+}
+
+export default function LoginPage() {
+  const [email, setEmail] = useState("");
+  const [pin, setPin] = useState("");
+  const [touched, setTouched] = useState({ email: false, pin: false });
+
+  const emailValid = isValidEmail(email);
+  const pinValid = pin.length === PIN_LENGTH;
+
+  const emailError = touched.email && !emailValid;
+  const pinError = touched.pin && !pinValid;
+  const canSubmit = emailValid && pinValid;
+
+  function handlePinChange(e: React.ChangeEvent<HTMLInputElement>) {
+    setPin(e.target.value.replace(/\D/g, "").slice(0, PIN_LENGTH));
+  }
+
+  function handleSubmit(e: React.FormEvent) {
+    // No authentication here — visual flow only.
+    e.preventDefault();
+    setTouched({ email: true, pin: true });
+  }
+
+  return (
+    <div className="flex min-h-screen items-center justify-center bg-[#F9FAFB] px-4 py-10 font-body">
+      <div className="w-full max-w-md">
+        {/* Logo */}
+        <div className="mb-6 flex items-center justify-center gap-2 sm:justify-start">
+          {/* eslint-disable-next-line @next/next/no-img-element */}
+          <img src="/assets/logo-icon.svg" alt="Learnault" className="h-7 w-7" />
+          <span className="font-heading text-[18px] font-bold text-[#0F172A]">
+            Learnault
+          </span>
+        </div>
+
+        <div className="rounded-2xl border border-[#E2E8F0] bg-white p-6 shadow-sm">
+          <div className="mb-6">
+            <h1 className="font-heading text-[28px] font-bold text-[#0F172A]">
+              Welcome back
+            </h1>
+            <p className="mt-1 text-sm text-[#475569]">
+              Sign in to keep learning and earning.
+            </p>
+          </div>
+
+          <form className="flex flex-col gap-4" onSubmit={handleSubmit} noValidate>
+            <Input
+              variant="email"
+              label="Email address"
+              placeholder="Enter your email"
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              onBlur={() => setTouched((t) => ({ ...t, email: true }))}
+              state={
+                emailError
+                  ? "error"
+                  : email && emailValid
+                    ? "filled"
+                    : "default"
+              }
+              errorMessage="Please enter a valid email address"
+            />
+
+            <div className="flex flex-col gap-1">
+              <Input
+                variant="pin"
+                label="PIN"
+                placeholder="Enter your 6-digit PIN"
+                value={pin}
+                onChange={handlePinChange}
+                onBlur={() => setTouched((t) => ({ ...t, pin: true }))}
+                state={pinError ? "error" : "default"}
+                errorMessage="Your PIN must be 6 digits"
+              />
+              <div className="flex justify-end">
+                <Button variant="link" size="sm">
+                  Forgot PIN?
+                </Button>
+              </div>
+            </div>
+
+            <Button
+              type="submit"
+              variant="primary"
+              disabled={!canSubmit}
+              className="mt-2 w-full"
+            >
+              Sign in
+            </Button>
+          </form>
+
+          <p className="mt-6 text-center text-sm text-[#475569]">
+            New to Learnault?{" "}
+            <a
+              href="/signup"
+              className="font-medium text-[#14B8A6] hover:underline"
+            >
+              Create an account
+            </a>
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/landing/hero.tsx
+++ b/src/components/landing/hero.tsx
@@ -1,6 +1,7 @@
 import Image from "next/image";
 import { Syne } from "next/font/google";
 import { heroBg, heroPeople, people } from "../../../public/assets";
+import { Button } from "@/components/ui/Button";
 
 const syne = Syne({
   subsets: ["latin"],
@@ -34,18 +35,12 @@ const Hero = () => {
           </p>
 
           <div className="grid grid-cols-2 items-center gap-3 sm:flex sm:mt-14 sm:flex-wrap sm:gap-4">
-            <button
-              type="button"
-              className="rounded-full bg-[#F4B42A] px-4 py-3 text-sm font-bold text-[#1A1A1A] transition hover:bg-[#e6a81f] sm:px-8"
-            >
+            <Button variant="primary" className="w-full sm:w-auto">
               Start Learning
-            </button>
-            <button
-              type="button"
-              className="rounded-full border border-[#D1D5DB] bg-[#F7F7F7] px-4 py-3 text-sm font-bold text-[#272A30] transition hover:bg-white sm:px-8"
-            >
+            </Button>
+            <Button variant="outline" className="w-full sm:w-auto">
               Explore Quests
-            </button>
+            </Button>
           </div>
 
           <div className="flex items-center justify-center gap-3 sm:justify-start">

--- a/src/components/landing/hero.tsx
+++ b/src/components/landing/hero.tsx
@@ -1,26 +1,27 @@
-import Image from "next/image";
-import { Syne } from "next/font/google";
-import { heroBg, heroPeople, people } from "../../../public/assets";
-import { Button } from "@/components/ui/Button";
+import { heroBg, heroPeople, people } from '../../../public/assets';
+
+import { Button } from '@/components/ui/Button';
+import Image from 'next/image';
+import { Syne } from 'next/font/google';
 
 const syne = Syne({
-  subsets: ["latin"],
-  weight: ["700", "800"],
+  subsets: ['latin'],
+  weight: ['700', '800'],
 });
 
 const Hero = () => {
   return (
     <section
-      className="relative flex min-h-screen items-center overflow-hidden bg-secondary-background"
+      className="relative flex items-center min-h-screen overflow-hidden bg-secondary-background"
       style={{
         backgroundImage: `url(${heroBg.src}), url("/assets/hero-bg.svg")`,
-        backgroundRepeat: "no-repeat, repeat",
-        backgroundSize: "cover, 980px auto",
-        backgroundPosition: "center, bottom center",
+        backgroundRepeat: 'no-repeat, repeat',
+        backgroundSize: 'cover, 980px auto',
+        backgroundPosition: 'center, bottom center',
       }}
     >
       <div className="relative mx-auto grid w-full max-w-[1180px] items-center gap-8 px-4 py-8 sm:px-6 sm:py-10 lg:grid-cols-[minmax(0,520px)_minmax(0,524px)] lg:justify-center lg:gap-12 lg:px-10 lg:py-12">
-      <div className="order-2 max-w-xl space-y-5 lg:order-1 lg:justify-self-center lg:space-y-7">
+        <div className="order-2 max-w-xl space-y-5 lg:order-1 lg:justify-self-center lg:space-y-7">
           <h1
             className={`${syne.className} max-w-[450px] text-2xl leading-[1.02] font-bold text-text-primary sm:text-6xl`}
           >
@@ -34,16 +35,16 @@ const Hero = () => {
             managers.
           </p>
 
-          <div className="grid grid-cols-2 items-center gap-3 sm:flex sm:mt-14 sm:flex-wrap sm:gap-4">
-            <button
+          <div className="grid items-center grid-cols-2 gap-3 sm:flex sm:mt-14 sm:flex-wrap sm:gap-4">
+            <Button
               type="button"
-              className="rounded-full bg-primary px-4 py-3 text-sm font-bold text-text-primary transition hover:bg-primary/90 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary sm:px-8"
+              className="px-4 py-3 text-sm font-bold transition rounded-full bg-primary text-text-primary hover:bg-primary/90 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary sm:px-8"
             >
               Start Learning
-            </button>
-            <button
+            </Button>
+            <Button
               type="button"
-              className="rounded-full border border-border bg-secondary-background px-4 py-3 text-sm font-bold text-text-primary transition hover:bg-surface focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary sm:px-8"
+              className="px-4 py-3 text-sm font-bold transition border rounded-full border-border bg-secondary-background text-text-primary hover:bg-surface focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary sm:px-8"
             >
               Explore Quests
             </Button>
@@ -55,7 +56,7 @@ const Hero = () => {
               alt="Learners joined"
               width={45}
               height={24}
-              className="h-6 w-auto"
+              className="w-auto h-6"
             />
             <p className="text-sm font-medium text-text-primary">
               1k+ Learners already joined
@@ -70,7 +71,7 @@ const Hero = () => {
             width={524}
             height={619}
             priority
-            className="h-auto w-full"
+            className="w-full h-auto"
           />
         </div>
       </div>

--- a/src/components/landing/value-preposition.tsx
+++ b/src/components/landing/value-preposition.tsx
@@ -1,24 +1,24 @@
-import { Syne } from "next/font/google";
-import { Button } from "@/components/ui/Button";
+import { Syne } from 'next/font/google';
+import { Button } from '@/components/ui/Button';
 
 const syne = Syne({
-  subsets: ["latin"],
-  weight: ["700", "800"],
+  subsets: ['latin'],
+  weight: ['700', '800'],
 });
 
 const ValueProposition = () => {
   return (
     <section
-      className="relative flex min-h-125 items-center justify-center overflow-hidden py-16 sm:min-h-150 sm:py-24 before:absolute before:inset-0 before:bg-black before:opacity-50 before:z-0"
+      className="relative flex items-center justify-center py-16 overflow-hidden min-h-125 sm:min-h-150 sm:py-24 before:absolute before:inset-0 before:bg-black before:opacity-50 before:z-0"
       style={{
         backgroundImage: ` url("/assets/hero-preposition.jpg")`,
-        backgroundRepeat: "no-repeat",
-        backgroundSize: "cover",
-        backgroundPosition: "center",
+        backgroundRepeat: 'no-repeat',
+        backgroundSize: 'cover',
+        backgroundPosition: 'center',
       }}
     >
       <svg
-        className="absolute top-0 right-0 h-full w-auto opacity-30"
+        className="absolute top-0 right-0 w-auto h-full opacity-30"
         viewBox="0 0 558 625"
         preserveAspectRatio="xMaxYMin meet"
         fill="none"
@@ -58,13 +58,17 @@ const ValueProposition = () => {
         <circle cx="1050" cy="420" r="3" fill="white" />
       </svg>
 
-      <div className="relative z-10 mx-auto max-w-3xl px-4 text-center sm:px-6 lg:px-10">
-        <div className="mb-9 text-white md:max-w-125">
-          <h2 className={`${syne.className} text-3xl font-bold sm:text-5xl lg:text-6xl`}>
+      <div className="relative z-10 max-w-3xl px-4 mx-auto text-center sm:px-6 lg:px-10">
+        <div className="text-white mb-9 md:max-w-125">
+          <h2
+            className={`${syne.className} text-3xl font-bold sm:text-5xl lg:text-6xl`}
+          >
             Start Learning.
           </h2>
 
-          <h2 className={`${syne.className} pb-4 pt-3 text-3xl font-bold sm:text-5xl lg:text-6xl`}>
+          <h2
+            className={`${syne.className} pb-4 pt-3 text-3xl font-bold sm:text-5xl lg:text-6xl`}
+          >
             Start Earning.
           </h2>
 
@@ -74,9 +78,9 @@ const ValueProposition = () => {
           </p>
         </div>
 
-        <button
+        <Button
           type="button"
-          className="mt-2 rounded-full border border-transparent bg-surface px-6 py-3 text-sm font-bold text-text-primary transition hover:bg-transparent sm:px-10 md:mt-8 hover:border-white focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white"
+          className="px-6 py-3 mt-2 text-sm font-bold transition border border-transparent rounded-full bg-surface text-text-primary hover:bg-transparent sm:px-10 md:mt-8 hover:border-white focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white"
         >
           Start Learning
         </Button>
@@ -86,4 +90,3 @@ const ValueProposition = () => {
 };
 
 export default ValueProposition;
-

--- a/src/components/landing/value-preposition.tsx
+++ b/src/components/landing/value-preposition.tsx
@@ -1,4 +1,5 @@
 import { Syne } from "next/font/google";
+import { Button } from "@/components/ui/Button";
 
 const syne = Syne({
   subsets: ["latin"],
@@ -77,12 +78,12 @@ const ValueProposition = () => {
           </p>
         </div>
 
-        <button
-          type="button"
-          className="rounded-full bg-white px-6 py-3 text-sm font-bold text-[#0F172A] transition hover:bg-transparent sm:px-10 md:mt-8 mt-2  border border-transparent cursor-pointer hover:border-white"
+        <Button
+          variant="outline"
+          className="mt-2 border-transparent bg-white text-[#0F172A] hover:border-white hover:bg-transparent hover:text-white sm:px-10 md:mt-8"
         >
           Start Learning
-        </button>
+        </Button>
       </div>
     </section>
   );

--- a/src/components/learn/lesson-view.tsx
+++ b/src/components/learn/lesson-view.tsx
@@ -1,0 +1,146 @@
+"use client";
+
+import { useState } from "react";
+import { Button } from "@/components/ui/Button";
+
+// Frontend/design only — static mock content, no fetching/backend.
+
+export interface LessonStep {
+  heading: string;
+  /** Lightweight illustration — kept as a plain <img> for low-bandwidth. */
+  image: { src: string; alt: string };
+  /** Short, simple-language paragraphs optimised for readability. */
+  body: string[];
+}
+
+export interface Lesson {
+  title: string;
+  steps: LessonStep[];
+}
+
+export const MOCK_LESSON: Lesson = {
+  title: "Stellar Basics",
+  steps: [
+    {
+      heading: "What is the Stellar network?",
+      image: { src: "/assets/learning-paths/global.svg", alt: "A connected globe" },
+      body: [
+        "Stellar is an open network that lets people send money across the world in seconds.",
+        "Instead of one company being in charge, many computers keep a shared record of every payment.",
+      ],
+    },
+    {
+      heading: "Wallets and keys",
+      image: {
+        src: "/assets/why-learnault/digital-wallet.svg",
+        alt: "A digital wallet",
+      },
+      body: [
+        "A wallet holds your funds and your keys. Your public key is like an address you can share.",
+        "Your secret key is private — it proves the account is yours, so never share it with anyone.",
+      ],
+    },
+    {
+      heading: "Earning while you learn",
+      image: { src: "/assets/why-learnault/earn.svg", alt: "A reward coin" },
+      body: [
+        "On Learnault you finish short lessons and quizzes to earn XLM rewards.",
+        "Your progress is recorded on Stellar, giving you verifiable proof of what you have learned.",
+      ],
+    },
+  ],
+};
+
+export function LessonView({
+  lesson = MOCK_LESSON,
+  onComplete,
+}: {
+  lesson?: Lesson;
+  onComplete?: () => void;
+}) {
+  const [index, setIndex] = useState(0);
+
+  const total = lesson.steps.length;
+  const step = lesson.steps[index];
+  const isFirst = index === 0;
+  const isLast = index === total - 1;
+  const progress = Math.round(((index + 1) / total) * 100);
+
+  return (
+    <article className="mx-auto flex min-h-screen w-full max-w-2xl flex-col gap-6 bg-[#F9FAFB] px-4 py-8 font-body sm:px-6">
+      {/* In-module progress */}
+      <header className="flex flex-col gap-2">
+        <div className="flex items-baseline justify-between">
+          <h1 className="font-heading text-[20px] font-bold text-[#0F172A]">
+            {lesson.title}
+          </h1>
+          <span className="text-[12px] font-medium text-[#94A3B8]">
+            Step {index + 1} of {total}
+          </span>
+        </div>
+        <div
+          className="h-1.5 w-full overflow-hidden rounded-full bg-[#E2E8F0]"
+          role="progressbar"
+          aria-valuemin={0}
+          aria-valuemax={total}
+          aria-valuenow={index + 1}
+          aria-label="Lesson progress"
+        >
+          <div
+            className="h-full rounded-full bg-[#F5B841] transition-all duration-300"
+            style={{ width: `${progress}%` }}
+          />
+        </div>
+      </header>
+
+      {/* Lesson content */}
+      <section className="flex flex-1 flex-col gap-5 rounded-2xl border border-[#E2E8F0] bg-white p-5 shadow-sm sm:p-7">
+        <div className="flex justify-center rounded-xl bg-[#F1F5F9] py-8">
+          {/* eslint-disable-next-line @next/next/no-img-element */}
+          <img
+            src={step.image.src}
+            alt={step.image.alt}
+            width={96}
+            height={96}
+            loading="lazy"
+            className="h-24 w-24"
+          />
+        </div>
+
+        <h2 className="font-heading text-[24px] font-bold leading-tight text-[#0F172A]">
+          {step.heading}
+        </h2>
+
+        <div className="flex flex-col gap-4">
+          {step.body.map((paragraph, i) => (
+            <p
+              key={i}
+              className="text-[18px] leading-relaxed text-[#475569]"
+            >
+              {paragraph}
+            </p>
+          ))}
+        </div>
+      </section>
+
+      {/* Navigation */}
+      <nav className="flex items-center justify-between gap-3">
+        <Button
+          variant="outline"
+          onClick={() => setIndex((i) => Math.max(0, i - 1))}
+          disabled={isFirst}
+        >
+          Back
+        </Button>
+        <Button
+          variant="primary"
+          onClick={() =>
+            isLast ? onComplete?.() : setIndex((i) => Math.min(total - 1, i + 1))
+          }
+        >
+          {isLast ? "Finish" : "Continue"}
+        </Button>
+      </nav>
+    </article>
+  );
+}

--- a/src/components/ui/Button.tsx
+++ b/src/components/ui/Button.tsx
@@ -1,55 +1,112 @@
+"use client";
+
+import * as React from "react";
 import { ArrowRight } from "lucide-react";
-import { ButtonHTMLAttributes } from "react";
+import { cva, type VariantProps } from "class-variance-authority";
+import { cn } from "@/lib/utils";
 
-type ButtonVariant = "primary" | "secondary" | "outline" | "link";
+/**
+ * Button — reusable CTA built per docs/design/design_system.md.
+ *
+ * Families:
+ *  - Solid:   primary (gold), secondary (light yellow), tertiary (beige/tan)
+ *  - Outline: white bg + dark border
+ *  - Link:    teal text + trailing arrow
+ *
+ * Every family has Default / Hover-Active / Disabled states and a
+ * keyboard-visible focus ring. Colors are pulled from the design tokens.
+ */
+const buttonVariants = cva(
+  "inline-flex items-center justify-center gap-2 font-body font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 disabled:cursor-not-allowed",
+  {
+    variants: {
+      variant: {
+        primary:
+          "rounded-full bg-[#F5B841] text-[#0F172A] hover:bg-[#E0A82F] focus-visible:ring-[#F5B841] disabled:bg-[#E2E8F0] disabled:text-[#94A3B8] disabled:hover:bg-[#E2E8F0]",
+        secondary:
+          "rounded-full bg-[#FEF3C7] text-[#0F172A] hover:bg-[#FDE68A] focus-visible:ring-[#F5B841] disabled:bg-[#E2E8F0] disabled:text-[#94A3B8] disabled:hover:bg-[#E2E8F0]",
+        tertiary:
+          "rounded-full bg-[#EADBC0] text-[#0F172A] hover:bg-[#E0CEAC] focus-visible:ring-[#D6BE97] disabled:bg-[#E2E8F0] disabled:text-[#94A3B8] disabled:hover:bg-[#E2E8F0]",
+        outline:
+          "rounded-full border border-[#D1D5DB] bg-white text-[#0F172A] hover:bg-[#F1F5F9] focus-visible:ring-[#475569] disabled:border-[#E2E8F0] disabled:text-[#94A3B8] disabled:hover:bg-white",
+        link: "rounded-sm text-[#14B8A6] hover:text-[#0F9387] focus-visible:ring-[#14B8A6] disabled:text-[#14B8A6]/50 disabled:hover:text-[#14B8A6]/50",
+      },
+      size: {
+        lg: "px-7 py-3.5 text-[20px]",
+        md: "px-6 py-3 text-[16px]",
+        sm: "px-5 py-2.5 text-[14px]",
+        xs: "px-4 py-2 text-[12px]",
+      },
+    },
+    compoundVariants: [
+      // Text/Link buttons carry no box padding regardless of size.
+      { variant: "link", class: "px-0 py-0" },
+    ],
+    defaultVariants: {
+      variant: "primary",
+      size: "md",
+    },
+  }
+);
 
-interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
-  variant?: ButtonVariant;
+export interface ButtonProps
+  extends React.ButtonHTMLAttributes<HTMLButtonElement>,
+    VariantProps<typeof buttonVariants> {
+  /** Shows a spinner and makes the button non-interactive. */
   loading?: boolean;
+  /** Optional leading icon slot. */
+  leftIcon?: React.ReactNode;
+  /** Optional trailing icon slot (overrides the link arrow). */
+  rightIcon?: React.ReactNode;
 }
 
-export function Button({
-  variant = "primary",
-  loading = false,
-  disabled,
-  children,
-  className = "",
-  ...props
-}: ButtonProps) {
-  const isDisabled = disabled || loading;
+export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
+  function Button(
+    {
+      variant = "primary",
+      size = "md",
+      loading = false,
+      disabled,
+      leftIcon,
+      rightIcon,
+      children,
+      className,
+      type = "button",
+      ...props
+    },
+    ref
+  ) {
+    const isDisabled = Boolean(disabled) || loading;
 
-  const base =
-    "inline-flex items-center justify-center gap-2 rounded-full px-6 py-3 text-[16px] font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2";
-
-  const variants: Record<ButtonVariant, string> = {
-    primary: isDisabled
-      ? "bg-[#E2E8F0] text-[#94A3B8] cursor-not-allowed"
-      : "bg-[#F5B841] text-[#0F172A] hover:bg-[#e6a81f] focus-visible:ring-[#F5B841]",
-    secondary: isDisabled
-      ? "bg-[#E2E8F0] text-[#94A3B8] cursor-not-allowed"
-      : "bg-[#FEF3C7] text-[#0F172A] hover:bg-[#fde68a] focus-visible:ring-[#F5B841]",
-    outline: isDisabled
-      ? "border border-[#E2E8F0] bg-white text-[#94A3B8] cursor-not-allowed"
-      : "border border-[#D1D5DB] bg-white text-[#0F172A] hover:bg-[#F7F7F7] focus-visible:ring-[#475569]",
-    link: isDisabled
-      ? "text-[#14B8A6]/50 cursor-not-allowed"
-      : "text-[#14B8A6] hover:text-[#0f9387] px-0 py-0 rounded-none",
-  };
-
-  return (
-    <button
-      disabled={isDisabled}
-      aria-disabled={isDisabled}
-      className={[base, variants[variant], className].join(" ")}
-      {...props}
-    >
-      {loading ? (
-        <span className="h-4 w-4 animate-spin rounded-full border-2 border-current border-t-transparent" />
-      ) : null}
-      {children}
-      {variant === "link" && !loading && (
+    // Link buttons get the design-system trailing arrow unless one is provided.
+    const trailing =
+      rightIcon ??
+      (variant === "link" && !loading ? (
         <ArrowRight size={16} aria-hidden="true" />
-      )}
-    </button>
-  );
-}
+      ) : null);
+
+    return (
+      <button
+        ref={ref}
+        type={type}
+        disabled={isDisabled}
+        aria-disabled={isDisabled}
+        aria-busy={loading || undefined}
+        className={cn(buttonVariants({ variant, size }), className)}
+        {...props}
+      >
+        {loading ? (
+          <span
+            role="status"
+            aria-label="Loading"
+            className="h-4 w-4 animate-spin rounded-full border-2 border-current border-t-transparent"
+          />
+        ) : (
+          leftIcon
+        )}
+        {children}
+        {trailing}
+      </button>
+    );
+  }
+);

--- a/tests/Button.test.tsx
+++ b/tests/Button.test.tsx
@@ -1,0 +1,105 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import { describe, it, expect, vi } from "vitest";
+import { createRef } from "react";
+import { Mail } from "lucide-react";
+import { Button } from "@/components/ui/Button";
+
+describe("Button", () => {
+  it("renders children and defaults to the solid primary variant", () => {
+    render(<Button>Start Learning</Button>);
+    const btn = screen.getByRole("button", { name: "Start Learning" });
+    expect(btn).toBeInTheDocument();
+    expect(btn.className).toMatch(/bg-\[#F5B841\]/);
+    // default type is button so it never submits an enclosing form by accident
+    expect(btn).toHaveAttribute("type", "button");
+  });
+
+  it("applies the correct classes for each solid + outline variant", () => {
+    const { rerender } = render(<Button variant="secondary">x</Button>);
+    expect(screen.getByRole("button").className).toMatch(/bg-\[#FEF3C7\]/);
+
+    rerender(<Button variant="tertiary">x</Button>);
+    expect(screen.getByRole("button").className).toMatch(/bg-\[#EADBC0\]/);
+
+    rerender(<Button variant="outline">x</Button>);
+    expect(screen.getByRole("button").className).toMatch(/border-\[#D1D5DB\]/);
+  });
+
+  it("renders the link variant with a trailing arrow and teal text", () => {
+    const { container } = render(<Button variant="link">Forgot PIN</Button>);
+    const btn = screen.getByRole("button", { name: /Forgot PIN/ });
+    expect(btn.className).toMatch(/text-\[#14B8A6\]/);
+    // link arrow is an inline SVG
+    expect(container.querySelector("svg")).toBeInTheDocument();
+  });
+
+  it("maps sizes to the design-system type scale", () => {
+    const { rerender } = render(<Button size="lg">x</Button>);
+    expect(screen.getByRole("button").className).toMatch(/text-\[20px\]/);
+
+    rerender(<Button size="sm">x</Button>);
+    expect(screen.getByRole("button").className).toMatch(/text-\[14px\]/);
+
+    rerender(<Button size="xs">x</Button>);
+    expect(screen.getByRole("button").className).toMatch(/text-\[12px\]/);
+  });
+
+  it("exposes a keyboard-visible focus ring", () => {
+    render(<Button>x</Button>);
+    expect(screen.getByRole("button").className).toMatch(
+      /focus-visible:ring-2/
+    );
+  });
+
+  it("is non-interactive and marked disabled when disabled", () => {
+    const onClick = vi.fn();
+    render(
+      <Button disabled onClick={onClick}>
+        x
+      </Button>
+    );
+    const btn = screen.getByRole("button");
+    expect(btn).toBeDisabled();
+    expect(btn).toHaveAttribute("aria-disabled", "true");
+    fireEvent.click(btn);
+    expect(onClick).not.toHaveBeenCalled();
+  });
+
+  it("shows a spinner and blocks clicks while loading", () => {
+    const onClick = vi.fn();
+    render(
+      <Button loading onClick={onClick}>
+        Submit
+      </Button>
+    );
+    const btn = screen.getByRole("button");
+    expect(btn).toBeDisabled();
+    expect(btn).toHaveAttribute("aria-busy", "true");
+    expect(screen.getByRole("status")).toBeInTheDocument();
+    fireEvent.click(btn);
+    expect(onClick).not.toHaveBeenCalled();
+  });
+
+  it("fires onClick when enabled and renders custom icon slots", () => {
+    const onClick = vi.fn();
+    render(
+      <Button onClick={onClick} leftIcon={<Mail data-testid="left" />}>
+        Continue
+      </Button>
+    );
+    expect(screen.getByTestId("left")).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button"));
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
+
+  it("merges custom className overrides and forwards a ref", () => {
+    const ref = createRef<HTMLButtonElement>();
+    render(
+      <Button ref={ref} className="w-full">
+        x
+      </Button>
+    );
+    expect(ref.current).toBeInstanceOf(HTMLButtonElement);
+    expect(ref.current?.className).toMatch(/w-full/);
+  });
+});

--- a/tests/lesson-view.test.tsx
+++ b/tests/lesson-view.test.tsx
@@ -1,0 +1,62 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import { describe, it, expect, vi } from "vitest";
+import { LessonView, MOCK_LESSON } from "@/components/learn/lesson-view";
+
+describe("LessonView", () => {
+  it("renders the first step's heading, body and illustration", () => {
+    render(<LessonView />);
+    const first = MOCK_LESSON.steps[0];
+    expect(
+      screen.getByRole("heading", { name: first.heading })
+    ).toBeInTheDocument();
+    expect(screen.getByText(first.body[0])).toBeInTheDocument();
+    expect(screen.getByAltText(first.image.alt)).toBeInTheDocument();
+  });
+
+  it("exposes an in-module progress affordance", () => {
+    render(<LessonView />);
+    expect(
+      screen.getByText(`Step 1 of ${MOCK_LESSON.steps.length}`)
+    ).toBeInTheDocument();
+    const bar = screen.getByRole("progressbar");
+    expect(bar).toHaveAttribute("aria-valuenow", "1");
+    expect(bar).toHaveAttribute(
+      "aria-valuemax",
+      String(MOCK_LESSON.steps.length)
+    );
+  });
+
+  it("advances to the next step via Continue and updates progress", () => {
+    render(<LessonView />);
+    fireEvent.click(screen.getByRole("button", { name: "Continue" }));
+
+    expect(
+      screen.getByRole("heading", { name: MOCK_LESSON.steps[1].heading })
+    ).toBeInTheDocument();
+    expect(screen.getByText("Step 2 of 3")).toBeInTheDocument();
+    expect(screen.getByRole("progressbar")).toHaveAttribute(
+      "aria-valuenow",
+      "2"
+    );
+  });
+
+  it("disables Back on the first step and re-enables it after advancing", () => {
+    render(<LessonView />);
+    expect(screen.getByRole("button", { name: "Back" })).toBeDisabled();
+    fireEvent.click(screen.getByRole("button", { name: "Continue" }));
+    expect(screen.getByRole("button", { name: "Back" })).toBeEnabled();
+  });
+
+  it("shows Finish on the last step and calls onComplete", () => {
+    const onComplete = vi.fn();
+    render(<LessonView onComplete={onComplete} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Continue" }));
+    fireEvent.click(screen.getByRole("button", { name: "Continue" }));
+
+    const finish = screen.getByRole("button", { name: "Finish" });
+    expect(finish).toBeInTheDocument();
+    fireEvent.click(finish);
+    expect(onComplete).toHaveBeenCalledTimes(1);
+  });
+});

--- a/tests/login.test.tsx
+++ b/tests/login.test.tsx
@@ -1,0 +1,54 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import { describe, it, expect } from "vitest";
+import LoginPage from "@/app/login/page";
+
+describe("Login screen", () => {
+  it("renders the heading, email + PIN fields and account links", () => {
+    render(<LoginPage />);
+    expect(
+      screen.getByRole("heading", { name: /Welcome back/i })
+    ).toBeInTheDocument();
+    expect(screen.getByLabelText("Email address")).toBeInTheDocument();
+    expect(screen.getByLabelText("PIN")).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /Forgot PIN/i })
+    ).toBeInTheDocument();
+    const createAccount = screen.getByRole("link", {
+      name: /Create an account/i,
+    });
+    expect(createAccount).toHaveAttribute("href", "/signup");
+  });
+
+  it("disables the sign-in button until both fields are valid", () => {
+    render(<LoginPage />);
+    const submit = screen.getByRole("button", { name: "Sign in" });
+    expect(submit).toBeDisabled();
+
+    fireEvent.change(screen.getByLabelText("Email address"), {
+      target: { value: "ada@learnault.xyz" },
+    });
+    fireEvent.change(screen.getByLabelText("PIN"), {
+      target: { value: "123456" },
+    });
+    expect(submit).toBeEnabled();
+  });
+
+  it("shows a visual email error after an invalid entry is blurred", () => {
+    render(<LoginPage />);
+    const email = screen.getByLabelText("Email address");
+    fireEvent.change(email, { target: { value: "not-an-email" } });
+    fireEvent.blur(email);
+
+    expect(email).toHaveAttribute("aria-invalid", "true");
+    expect(screen.getByRole("alert")).toHaveTextContent(
+      "Please enter a valid email address"
+    );
+  });
+
+  it("only accepts up to 6 numeric digits in the PIN field", () => {
+    render(<LoginPage />);
+    const pin = screen.getByLabelText("PIN") as HTMLInputElement;
+    fireEvent.change(pin, { target: { value: "12ab3456789" } });
+    expect(pin.value).toBe("123456");
+  });
+});


### PR DESCRIPTION
## #163 — Reusable Button component
Replaces the partial Button and raw landing-page `<button>` elements with a
token-driven component built on `class-variance-authority`, per
`docs/design/design_system.md`.

- Solid: primary (gold), secondary (light yellow), tertiary (beige/tan)
- Outline: white bg + dark border
- Text/Link: teal text with trailing arrow
- Sizes: lg (20px), md (16px), sm (14px), xs (12px)
- Default / Hover / Disabled states, keyboard-visible focus ring, leading/
  trailing icon slots, loading spinner, forwarded ref
- Hero and ValueProposition CTAs refactored onto the component

## #170 — Returning-user login screen (`/login`)
Frontend/design only — no real authentication.

- Email + PIN entry reusing the Input (email/pin) and Button components
- Forgot-PIN and create-account links
- Visual-only validation (Input error state, disabled submit)
- Token-driven and accessible (labelled fields, aria-invalid, role="alert")

## #171 — Bite-sized lesson / learning module view (`/learn`)
Frontend/design only — static mock content, no fetching/backend.

- Readable, mobile-first layout: illustration + simple-language paragraphs at
  the body-large type scale; low-bandwidth lazy `<img>`
- In-module progress indicator (Step X of N + accessible progressbar)
- Back / Continue navigation via the Button component, Finish on the last step

## Testing
- New suites: `tests/Button.test.tsx` (9), `tests/login.test.tsx` (4),
  `tests/lesson-view.test.tsx` (5) — all passing
- `tsc --noEmit` and `eslint` clean on all changed files

Closes #163
Closes #170
Closes #171
